### PR TITLE
chore(package): add a noop postinstall script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1] - 2016-12-19
+### Fixed
+- Busbar deployment by adding a noop postinstall script
+
 ## [1.0.0] - 2016-12-19
 ### Added:
 - Initial release

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dev": "nodemon -x 'npm run lint && npm run test'",
     "lint": "./node_modules/eslint/bin/eslint.js .",
     "start": "node index.js",
+    "postinstall": "echo 'noop'",
     "test": "istanbul cover -x '*spec.js' ./node_modules/.bin/jasmine"
   },
   "version": "1.0.0"


### PR DESCRIPTION
As it currently stands, Busbar cannot deploy Node applications that do
not have an `npm postinstall` script. This commit fixes that issue by
adding a noop script to `package.json`.